### PR TITLE
Add Typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+declare module 'vue-promise-btn' {
+  import _Vue, { Component, VNode, CreateElement, DirectiveOptions } from 'vue';
+
+  export interface VuePromiseBtnOptions {
+    btnLoadingClass?: string;
+    spinnerHiddenClass?: string;
+    action?: string;
+    minTimeout?: number;
+    disableBtn?: boolean;
+    showSpinner?: boolean;
+    autoHideSpinnerWrapper?: boolean;
+    loader?: Component | string;
+    stringHTMLRenderer?: (options: VuePromiseBtnOptions) => string;
+    componentRenderer?: (options: VuePromiseBtnOptions) => (h: CreateElement) => () => VNode;
+  }
+
+  export function install(Vue: typeof _Vue, options?: VuePromiseBtnOptions): void;
+
+  export function setupVuePromiseBtn(globalOptions: VuePromiseBtnOptions): DirectiveOptions;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-promise-btn",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Vue.js plugin that handles buttons asynchronous lock and show loading state indicator",
   "scripts": {
     "start": "npm run dev",
@@ -20,6 +20,7 @@
   "main": "dist/vue-promise-btn.common.js",
   "unpkg": "dist/vue-promise-btn.umd.js",
   "style": "dist/vue-promise-btn.css",
+  "typings": "./index.d.ts",
   "keywords": [
     "vue",
     "promise",
@@ -33,7 +34,8 @@
   ],
   "files": [
     "dist/",
-    "src/"
+    "src/",
+    "index.d.ts"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
After Installation `vue-promise-btn` into Typescript project it asks to install types, or declare types by your own.

This PR resolves issue with quite long Typescript project startup.